### PR TITLE
Add alternative bibliography format.

### DIFF
--- a/appendix.typ
+++ b/appendix.typ
@@ -9,6 +9,7 @@
 == Quellenverzeichnis
 
 #bibliography("references.bib", style: "ieee", title: none)
+//#bibliography("references.yaml", style: "ieee", title: none)
 
 #pagebreak()
 

--- a/references.yaml
+++ b/references.yaml
@@ -1,0 +1,6 @@
+ordDoc:
+  type: web
+  author: Python Software Foundation
+  title: Built-in Functions
+  date: 2025
+  url: { value: https://docs.python.org/3.4/library/functions.html#ord, date: 2025-03-28 }


### PR DESCRIPTION
Add alternative bibliography format (Hayagriva .yml).
https://typst.app/docs/reference/model/bibliography/
https://github.com/typst/hayagriva/blob/main/docs/file-format.md